### PR TITLE
Tune: Stricter black detection threshold

### DIFF
--- a/js/image_processing.js
+++ b/js/image_processing.js
@@ -16,7 +16,7 @@ const EXPECTED_MARKER_WHITE_RGB = { r: 255, g: 255, b: 255 };
 // for a color to be considered 'close enough' to a target color.
 // E.g., if target is black (0,0,0), a pixel (10,20,30) has distance 10+20+30=60.
 // If COLOR_DISTANCE_THRESHOLD_MARKER is 150, this pixel would be considered 'black-ish'.
-const COLOR_DISTANCE_THRESHOLD_MARKER = 150; // Tune this value as needed
+const COLOR_DISTANCE_THRESHOLD_MARKER = 80; // Adjusted to be stricter for black detection
 
 /**
  * Calculates the Manhattan distance between two RGB colors.


### PR DESCRIPTION
Adjusted `COLOR_DISTANCE_THRESHOLD_MARKER` in
`js/image_processing.js` from 150 to 80.

This change makes the initial identification of "black-ish" pixels in `findMarkerCandidates_color` more selective. The goal is to reduce the likelihood of non-black pixels being included in the initial binary mask, thereby improving the quality of blobs found by the subsequent Connected Components Labeling.

This should help the "center is not black" filter within `findMarkerCandidates_color` to more accurately identify true marker frames (black borders with non-black centers) by starting with cleaner, more genuinely black candidate regions.

Relaxed geometric filters and the center-check logic remain active for ongoing diagnostics.