### PR TITLE
It looks like the bugfix you're working on addresses a problem where …

### DIFF
--- a/js/image_processing.js
+++ b/js/image_processing.js
@@ -1719,11 +1719,11 @@ function findMarkersFromCells(allCells, markerCellPattern, avgCellWidth, avgCell
                 foundMarkers.push({
                     x: markerX, y: markerY, width: markerWidth, height: markerHeight,
                     area: markerWidth * markerHeight,
-                    points: [ // TL, TR, BR, BL of the marker bounding box
-                        { x: markerX, y: markerY },
-                        { x: markerX + markerWidth, y: markerY },
-                        { x: markerX + markerWidth, y: markerY + markerHeight },
-                        { x: markerX, y: markerY + markerHeight }
+                    points: [ // TL, TR, BR, BL of the marker bounding box (inclusive coordinates)
+                        { x: markerX, y: markerY },                                     // Top-left
+                        { x: markerX + markerWidth - 1, y: markerY },                   // Top-right
+                        { x: markerX + markerWidth - 1, y: markerY + markerHeight - 1 }, // Bottom-right
+                        { x: markerX, y: markerY + markerHeight - 1 }                   // Bottom-left
                     ],
                     // Optional: store the constituent cells for debugging
                     // constituentCells: currentMarkerCells.flat().filter(Boolean) 


### PR DESCRIPTION
…the perspective transformation matrix was getting `NaN` values, which then caused issues with image warping and decoding.

The problem seems to stem from an off-by-one error when defining the `points` array for marker objects in the `findMarkersFromCells` function. It appears the coordinates were using exclusive end boundaries instead of inclusive pixel boundaries.

This commit updates the `points` array definition in `findMarkersFromCells` to use inclusive coordinates for the marker bounding boxes. This should ensure valid input for the perspective transformation, allowing the matrix to be calculated correctly and the rest of the decoding process to work with a properly warped image.